### PR TITLE
fix Windows-style line endings (CRLF)

### DIFF
--- a/MCP/setup_unreal_mcp.bat
+++ b/MCP/setup_unreal_mcp.bat
@@ -143,7 +143,7 @@ echo 1. Run run_unreal_mcp.bat to start the MCP bridge
 echo 2. Open Claude Desktop and it should automatically use the correct configuration
 echo ========================================================
 echo.
-echo Press any key to exit...
+echo Please Press any key to exit...
 pause >nul
 
 :end


### PR DESCRIPTION
“'al' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'nreal' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
't' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'CRIPT_DIR' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'CRIPT_DIR' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'et' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'NV_DIR' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'ODULES_DIR' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'Setting' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
'eck' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
这样导致配置mcp的时候失败了”
The errors  when running the setup_unreal_mcp.bat script on Windows 10 indicate that the batch file is not being interpreted correctly by the command prompt. The error messages suggest that the script's commands are being misparsed, with parts of variable names or commands (e.g., 'al', 'nreal', 'CRIPT_DIR', 'et', etc.) being treated as separate commands. This is due to issues with the script file's  line endings。